### PR TITLE
[Refactor/#1] 로컬 파일 저장 → S3 업로드 및 presigned URL 다운로드 방식 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,10 @@ dependencies {
 
     // pdf
     implementation 'org.apache.pdfbox:pdfbox:2.0.29'
+
+    // aws sdk
+    implementation platform('software.amazon.awssdk:bom:2.20.56')
+    implementation 'software.amazon.awssdk:s3'
 }
 
 dependencyManagement {

--- a/src/main/java/com/kitcha/board/config/S3Config.java
+++ b/src/main/java/com/kitcha/board/config/S3Config.java
@@ -1,0 +1,35 @@
+package com.kitcha.board.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+
+@Configuration
+public class S3Config {
+    /**
+     * S3 클라이언트 생성
+     * 객체 업로드/다운로드 등의 작업에 사용
+     *
+     * @return S3 클라이언트 인스턴스
+     */
+    @Bean
+    public S3Client s3Client() {
+        return S3Client.builder().region(Region.AP_NORTHEAST_2).build();
+    }
+
+    /**
+     * 파일 다운로드 시 임시 접근 URL을 만들 때 사용
+     * @return S3Presigner 인스턴스
+     */
+    @Bean
+    public S3Presigner s3Presigner() {
+        return S3Presigner.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .credentialsProvider(DefaultCredentialsProvider.create())
+                .build();
+    }
+}

--- a/src/main/java/com/kitcha/board/controller/BoardController.java
+++ b/src/main/java/com/kitcha/board/controller/BoardController.java
@@ -5,7 +5,6 @@ import com.kitcha.board.dto.BoardDetail;
 import com.kitcha.board.dto.BoardList;
 import com.kitcha.board.dto.BoardUpdate;
 import com.kitcha.board.entity.Board;
-import com.kitcha.board.entity.File;
 import com.kitcha.board.service.BoardService;
 import com.kitcha.board.service.FileService;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,12 +13,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.io.IOException;
-import java.net.URLEncoder;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.List;
-import java.util.Optional;
 
 @RestController
 @RequestMapping("/apps/board")
@@ -87,26 +81,9 @@ public class BoardController {
 
     // 6. 첨부파일 다운로드
     @GetMapping("/{boardId}/download")
-    public void download(@PathVariable Long boardId,
+    public String download(@PathVariable Long boardId,
                          HttpServletResponse response) throws IOException {
-        Optional<File> optional = fileService.download(boardId);
 
-        if (optional.isEmpty()) {
-            return;
-        }
-
-        File file = optional.get();
-
-        Path path = Paths.get(file.getFilePath());
-        byte[] result = Files.readAllBytes(path);
-
-        response.setContentType("application/octet-stream");
-        response.setContentLength(result.length);
-        response.setHeader("Content-Disposition",
-                "attachment; fileName=\"" + URLEncoder.encode(file.getFileName() + ".pdf", "UTF-8") + "\";");
-        response.setHeader("Content-Transfer-Encoding", "binary");
-        response.getOutputStream().write(result);
-        response.getOutputStream().flush();
-        response.getOutputStream().close();
+        return fileService.getPresignedFileUrl(boardId);
     }
 }

--- a/src/main/java/com/kitcha/board/service/S3Service.java
+++ b/src/main/java/com/kitcha/board/service/S3Service.java
@@ -1,0 +1,72 @@
+package com.kitcha.board.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.GetObjectPresignRequest;
+
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+    // AWS 버킷명 (환경변수로 관리)
+    @Value("${AWS_S3_BUCKET}")
+    private String bucket;
+
+    private final S3Client s3Client;
+    private final S3Presigner s3Presigner;
+
+    /**
+     * 주어진 S3 경로에 파일 업로드
+     * @param s3Path S3에 저장될 객체의 키 (경로)
+     * @param fileBytes 업로드할 파일의 바이트 배열
+     */
+    public void uploadFileToS3(String s3Path, byte[] fileBytes) {
+        PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(s3Path)
+                .acl(ObjectCannedACL.BUCKET_OWNER_FULL_CONTROL)
+                .build();
+
+        s3Client.putObject(putObjectRequest, RequestBody.fromBytes(fileBytes));
+    }
+
+    /**
+     * 지정된 S3 객체 키와 파일명을 기반으로 Presigned URL 생성
+     * 이 URL은 일정 시간 동안만 유효하며, 파일 다운로드에 사용됨
+     *
+     * @param key S3 객체 키 (파일 경로)
+     * @param fileName 다운로드될 파일 이름 (확장자 제외)
+     * @return 생성된 Presigned URL (옵셔널)
+     */
+    public Optional<String> generatePresignedUrl(String key, String fileName) {
+        String encodedFileName = URLEncoder.encode(fileName + ".pdf", StandardCharsets.UTF_8).replaceAll("\\+", "%20");
+
+        GetObjectRequest getObjectRequest = GetObjectRequest.builder()
+                .bucket(bucket)
+                .responseContentDisposition("attachment; filename*=UTF-8''" + encodedFileName)
+                .responseContentType("application/pdf")
+                .key(key)
+                .build();
+
+        GetObjectPresignRequest presignRequest = GetObjectPresignRequest.builder()
+                .signatureDuration(Duration.ofMinutes(3))
+                .getObjectRequest(getObjectRequest)
+                .build();
+
+        URL presignedUrl = s3Presigner.presignGetObject(presignRequest).url();
+
+        return Optional.of(presignedUrl.toString());
+    }
+}


### PR DESCRIPTION
### 변경 내용
- 기존 파일 저장 방식을 로컬 → AWS S3 업로드로 리팩토링
- AWS SDK (`S3Client`, `S3Presigner`) 기반으로 파일 업로드 및 presigned URL 생성 로직 구현
- `application/pdf` MIME 타입과 Content-Disposition 설정 추가로 파일명 유지
- 환경변수를 통한 버킷 정보 관리 (`AWS_S3_BUCKET`)

### 목적
- MSA 구조에서 클라우드 환경 대응
- 파일 공유 및 접근 제어를 위한 presigned URL 기반 다운로드 방식 도입
- 보안 및 유지보수 측면에서 로컬 디스크 의존성 제거

### 관련 이슈
- Close #1 